### PR TITLE
Add doc and example on using different bucket types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ couchbase_bucket
 
 * `bucket` - The name to use for the Couchbase bucket, defaults to the resource name
 * `cluster` - The name of the cluster the bucket belongs to, defaults to "default"
+* `type` - The type of the bucket, defaults to "couchbase"
 * `memory_quota_mb` - The bucket's per server RAM quota for the entire cluster in megabytes
 * `memory_quota_percent` The bucket's RAM quota as a percent (0.0-1.0) of the cluster's quota
 * `replicas` - Number of replica (backup) copies, defaults to 1. Set to false to disable
@@ -184,6 +185,16 @@ couchbase_bucket "pillowfight" do
   username "Administrator"
   password "password"
 end
+
+couchbase_bucket "memcached" do
+  memory_quota_mb 128
+  replicas false
+  type "memcached"
+
+  username "Administrator"
+  password "password"
+end
+
 ```
 
 Chef Solo Note


### PR DESCRIPTION
I saw them supported in the code but not in the readme.

By the way, it is really convenient when the chef opscode community cookbook
(http://community.opscode.com/cookbooks/couchbase) links right to the git page.  I wouldn't have even known there was a git page without seeing the link in one of the community comments.  Putting it on the community homepage could increase the chances of other community pull requests.
