### PR TITLE
fixed attribute level of password

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -41,7 +41,7 @@ if Chef::Config[:solo]
   end
 else
   # generate all passwords
-  node.set_unless['couchbase']['server']['password'] = secure_password
+  node.default_unless['couchbase']['server']['password'] = secure_password
   node.save
 end
 


### PR DESCRIPTION
set_unless sets attribute even when a value already exists at another precendence level so it doesn't recommend.
http://tickets.opscode.com/browse/CHEF-2945
