### PR TITLE
Handle incompatibility for Vagrant 1.3.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,9 +56,12 @@ Vagrant.configure("2") do |config|
   #
   # View the documentation for the provider you're using for more
   # information on available options.
-
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
+  if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new("1.3.0")
+    config.vm.boot_timeout = 120
+  else
+    config.ssh.max_tries = 40
+    config.ssh.timeout   = 120
+  end
 
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"


### PR DESCRIPTION
In Vagrant 1.3.0, `config.ssh.max_tries` is gone and `config.ssh.timeout` has been replaced by `config.vm.boot_timeout`

I updated the Vagrantfile for compatibility with 1.3.0 and up.

[Vagrant Changelog](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md)
