### PR TITLE
Changed reference to deprecated yum_key to yum_repository

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "jdunn@getchef.com"
 license          "MIT"
 description      "Installs and configures Couchbase Server."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "1.2.2"
+version          "1.2.1"
 
 %w{debian ubuntu centos redhat oracle amazon scientific windows}.each do |os|
   supports os


### PR DESCRIPTION
This change replaces the deprecated yum_key attribute as per the yum 3.x cookbook README: "Changes have been made to the yum_repository resource, and the yum_key resource has been eliminated entirely. "
