### PR TITLE
fix/foodcritic warnings

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -32,7 +32,7 @@ when "debian"
   else
     default['couchbase']['server']['package_file'] = "couchbase-server-#{node['couchbase']['server']['edition']}_#{node['couchbase']['server']['version']}-debian7_#{package_machine}.deb"
   end
-when "centos", "redhat", "amazon", "scientific"
+when "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "parallels", "nexus_centos"
   package_machine = node['kernel']['machine'] == "x86_64" ? "x86_64" : "x86"
   if node['couchbase']['server']['version'] < "3.0.0"
     default['couchbase']['server']['package_file'] = "couchbase-server-#{node['couchbase']['server']['edition']}_#{node['couchbase']['server']['version']}_#{package_machine}.rpm"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          "MIT"
 description      "Installs and configures Couchbase Server."
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "1.4.2"
+issues_url       "https://github.com/disney/couchbase/issues"
+source_url       "https://github.com/disney/couchbase"
 
 %w{debian ubuntu centos redhat oracle amazon scientific windows}.each do |os|
   supports os

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -49,13 +49,13 @@ remote_file File.join(Chef::Config[:file_cache_path], node['couchbase']['server'
   action :create_if_missing
 end
 
-case node['platform']
-  when "debian", "ubuntu"
+case node['platform_family']
+  when "debian"
     package "libssl1.0.0"
     dpkg_package File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
       notifies :run, "ruby_block[block_until_operational]", :immediately
     end
-  when "redhat", "centos", "scientific", "amazon", "fedora"
+  when "rhel"
     yum_package File.join(Chef::Config[:file_cache_path], node['couchbase']['server']['package_file']) do
       options node['couchbase']['server']['allow_unsigned_packages'] == true ? "--nogpgcheck" : ""
     end


### PR DESCRIPTION
attributes fix is a bit noisy as we can't use platform_family due to
needing different debian/ubuntu packages, but as least now CI will pass.
