### PR TITLE
use ||= when assigning constants (fixes #71)

### DIFF
--- a/libraries/max_memory_quota_calculator.rb
+++ b/libraries/max_memory_quota_calculator.rb
@@ -1,7 +1,7 @@
 module Couchbase
   class MaxMemoryQuotaCalculator
-    MAX_MEMORY_PERCENT = 0.8
-    RESERVE_BYTES = 1024 * 1024 * 1024 # 1 gigabyte
+    MAX_MEMORY_PERCENT ||= 0.8
+    RESERVE_BYTES ||= 1024 * 1024 * 1024 # 1 gigabyte
 
     attr_reader :total_in_bytes
 


### PR DESCRIPTION
Resolves issue #71 