### PR TITLE
Make cookbook compatible with Chef 13+

### DIFF
--- a/attributes/cluster.rb
+++ b/attributes/cluster.rb
@@ -28,9 +28,9 @@ include_attribute "couchbase::server"
 
 default['couchbase']['cluster'] = Chef::DataBagItem.load('couchbase', 'cluster')[node.chef_environment] rescue {}
 
-default['couchbase']['cluster']['name'] = "default" unless node['couchbase']['cluster']['name']
+default['couchbase']['cluster']['name'] = "default"# unless node['couchbase']['cluster']['name']
 
 # If this server is a member of a cluster, the cluster settings should override some server settings
-override['couchbase']['server']['username'] = node['couchbase']['cluster']['username']
-override['couchbase']['server']['password'] = node['couchbase']['cluster']['password']
-override['couchbase']['server']['memory_quota_mb'] = node['couchbase']['cluster']['memory_quota_mb']
+override['couchbase']['server']['username'] = node['couchbase']['cluster']['username'] if node['couchbase']['cluster']['username']
+override['couchbase']['server']['password'] = node['couchbase']['cluster']['password'] if node['couchbase']['cluster']['password']
+override['couchbase']['server']['memory_quota_mb'] = node['couchbase']['cluster']['memory_quota_mb'] if node['couchbase']['cluster']['memory_quota_mb']

--- a/attributes/cluster.rb
+++ b/attributes/cluster.rb
@@ -28,9 +28,9 @@ include_attribute "couchbase::server"
 
 default['couchbase']['cluster'] = Chef::DataBagItem.load('couchbase', 'cluster')[node.chef_environment] rescue {}
 
-node.set['couchbase']['cluster']['name'] = "default" unless node['couchbase']['cluster']['name']
+default['couchbase']['cluster']['name'] = "default" unless node['couchbase']['cluster']['name']
 
 # If this server is a member of a cluster, the cluster settings should override some server settings
-node.set['couchbase']['server']['username'] = node['couchbase']['cluster']['username']
-node.set['couchbase']['server']['password'] = node['couchbase']['cluster']['password']
-node.set['couchbase']['server']['memory_quota_mb'] = node['couchbase']['cluster']['memory_quota_mb']
+override['couchbase']['server']['username'] = node['couchbase']['cluster']['username']
+override['couchbase']['server']['password'] = node['couchbase']['cluster']['password']
+override['couchbase']['server']['memory_quota_mb'] = node['couchbase']['cluster']['memory_quota_mb']

--- a/libraries/bucket_provider.rb
+++ b/libraries/bucket_provider.rb
@@ -7,6 +7,9 @@ class Chef
     class CouchbaseBucket < Provider
       include Couchbase::Client
       include Couchbase::ClusterData
+      provides :couchbase_bucket
+
+
 
       def load_current_resource
         @current_resource = Resource::CouchbaseBucket.new @new_resource.name

--- a/libraries/bucket_resource.rb
+++ b/libraries/bucket_resource.rb
@@ -5,6 +5,7 @@ class Chef
   class Resource
     class CouchbaseBucket < Resource
       include Couchbase::CredentialsAttributes
+      provides :couchbase_bucket
 
       def bucket(arg=nil)
         set_or_return(:bucket, arg, :kind_of => String, :name_attribute => true)
@@ -17,7 +18,7 @@ class Chef
       def exists(arg=nil)
         set_or_return(:exists, arg, :kind_of => [TrueClass, FalseClass], :required => true)
       end
-      
+
       def proxyport(arg=nil)
         set_or_return(:proxyport, arg, :kind_of => Integer)
       end

--- a/libraries/cluster_provider.rb
+++ b/libraries/cluster_provider.rb
@@ -1,12 +1,13 @@
-require "chef/provider"
-require File.join(File.dirname(__FILE__), "client")
-require File.join(File.dirname(__FILE__), "cluster_data")
+require 'chef/provider'
+require_relative 'client'
+require_relative 'cluster_data'
 
 class Chef
   class Provider
-    class CouchbaseCluster < Provider
+    class CouchbaseCluster < Chef::Provider
       include Couchbase::Client
       include Couchbase::ClusterData
+      provides :couchbase_cluster
 
       def load_current_resource
         @current_resource = Resource::CouchbaseCluster.new @new_resource.name

--- a/libraries/cluster_resource.rb
+++ b/libraries/cluster_resource.rb
@@ -1,10 +1,11 @@
-require "chef/resource"
-require File.join(File.dirname(__FILE__), "credentials_attributes")
+require 'chef/resource'
+require_relative 'credentials_attributes'
 
 class Chef
   class Resource
     class CouchbaseCluster < Resource
       include Couchbase::CredentialsAttributes
+      provides :couchbase_cluster
 
       def cluster(arg=nil)
         set_or_return(:cluster, arg, :kind_of => String, :name_attribute => true)

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -23,7 +23,6 @@
 # Shamelessly stolen from Opscode's jenkins cookbook. Works for now.
 
 require 'chef/mixin/shell_out'
-require 'chef/rest'
 
 module CouchbaseHelper
   extend Chef::Mixin::ShellOut

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -37,20 +37,13 @@ module CouchbaseHelper
   end
 
   def self.endpoint_responding?(url)
-    # XXX Should probably not use Chef::REST for this. Chef::REST only
-    # Accepts application/json; why not just use Net::HTTP directly?
-    begin
-      response = Chef::REST::RESTRequest.new(:GET, url, nil).call
-    rescue Errno::ECONNREFUSED, Errno::ENETUNREACH
-      return false
-    end
-    if response.kind_of?(Net::HTTPSuccess) ||
-          response.kind_of?(Net::HTTPRedirection) ||
-          response.kind_of?(Net::HTTPForbidden)
+    response = Net::HTTP.get_response(url, nil)
+    case response
+    when Net::HTTPSuccess, Net::HTTPRedirection, Net::HTTPForbidden
       Chef::Log.debug("GET to #{url} successful")
       return true
     else
-      Chef::Log.debug("GET to #{url} returned #{response.code} / #{response.class}")
+      Chef::Log.debug("GET to #{url} returned #{response.body if response.response_body_permitted?} / #{response}")
       return false
     end
   rescue EOFError, Errno::ECONNREFUSED

--- a/libraries/node_provider.rb
+++ b/libraries/node_provider.rb
@@ -1,11 +1,13 @@
-require "chef/provider"
-require "net/http"
-require File.join(File.dirname(__FILE__), "client")
+require 'chef/provider'
+require 'net/http'
+require_relative 'client'
 
 class Chef
   class Provider
-    class CouchbaseNode < Provider
+    class CouchbaseNode < Chef::Provider::LWRPBase
       include Couchbase::Client
+      provides :couchbase_node
+
 
       def load_current_resource
         @current_resource = Chef::Resource::CouchbaseNode.new @new_resource.name

--- a/libraries/node_provider.rb
+++ b/libraries/node_provider.rb
@@ -4,7 +4,7 @@ require_relative 'client'
 
 class Chef
   class Provider
-    class CouchbaseNode < Chef::Provider::LWRPBase
+    class CouchbaseNode < Chef::Provider
       include Couchbase::Client
       provides :couchbase_node
 

--- a/libraries/node_resource.rb
+++ b/libraries/node_resource.rb
@@ -1,10 +1,13 @@
-require "chef/resource"
-require File.join(File.dirname(__FILE__), "credentials_attributes")
+require 'chef/resource'
+require_relative 'credentials_attributes'
+require_relative 'client'
 
 class Chef
   class Resource
-    class CouchbaseNode < Resource
+    class CouchbaseNode < Chef::Resource
       include Couchbase::CredentialsAttributes
+      include Couchbase::Client
+      provides :couchbase_node
 
       def id(arg=nil)
         set_or_return(:id, arg, :kind_of => String, :name_attribute => true)

--- a/libraries/settings_provider.rb
+++ b/libraries/settings_provider.rb
@@ -5,6 +5,7 @@ class Chef
   class Provider
     class CouchbaseSettings < Provider
       include Couchbase::Client
+      provides :couchbase_settings
 
       def load_current_resource
         @current_resource = Resource::CouchbaseSettings.new @new_resource.name

--- a/libraries/settings_resource.rb
+++ b/libraries/settings_resource.rb
@@ -5,6 +5,7 @@ class Chef
   class Resource
     class CouchbaseSettings < Resource
       include Couchbase::CredentialsAttributes
+      provides :couchbase_settings
 
       def group(arg=nil)
         set_or_return(:group, arg, :kind_of => String, :name_attribute => true)


### PR DESCRIPTION
The cookbook was old methods and includes, which broke it's workings on newer versions of chef-client. This PR fixes those problems.